### PR TITLE
Add ID property to NFCMessage

### DIFF
--- a/android/src/main/java/me/andisemler/nfc_in_flutter/NfcInFlutterPlugin.java
+++ b/android/src/main/java/me/andisemler/nfc_in_flutter/NfcInFlutterPlugin.java
@@ -14,6 +14,7 @@ import android.os.Handler;
 import android.util.Log;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -215,6 +216,10 @@ public class NfcInFlutterPlugin implements MethodCallHandler,
             recordMap.put("tnf", String.valueOf(record.getTnf()));
             records.add(recordMap);
         }
+        byte[] idByteArray = ndef.getTag().getId();
+        // Fancy string formatting snippet is from
+        // https://gist.github.com/luixal/5768921#gistcomment-1788815
+        result.put("id", String.format("%0" + (idByteArray.length * 2) + "X", new BigInteger(1, idByteArray)));
         result.put("message_type", "ndef");
         result.put("type", ndef.getType());
         result.put("records", records);

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -50,7 +50,7 @@ class NFC {
           ));
         }
 
-        return NDEFMessage(tag["type"], records);
+        return NDEFMessage(tag["type"], records, id: tag["id"] ?? "");
       });
     }
     // Create a StreamController to wrap the tag stream. Any errors will be

--- a/lib/src/messages.dart
+++ b/lib/src/messages.dart
@@ -3,14 +3,16 @@ enum MessageType {
 }
 
 abstract class NFCMessage {
+  String get id;
   MessageType get messageType;
 }
 
 class NDEFMessage implements NFCMessage {
+  String id;
   final String type;
   final List<NDEFRecord> records;
 
-  NDEFMessage(this.type, this.records);
+  NDEFMessage(this.type, this.records, {this.id});
 
   // payload returns the contents of the first non-empty record. If all records
   // are empty it will return null.


### PR DESCRIPTION
Not yet available on iOS due to API restrictions. Will revisit when I start developing the ‘iOS tag’ reader mode (iOS 13 [`NFCTagReaderSession`](https://developer.apple.com/documentation/corenfc/nfctagreadersession?language=objc)).

Closes #7 