### PR TITLE
Better support for reading empty tags

### DIFF
--- a/android/src/main/java/me/andisemler/nfc_in_flutter/NfcInFlutterPlugin.java
+++ b/android/src/main/java/me/andisemler/nfc_in_flutter/NfcInFlutterPlugin.java
@@ -235,6 +235,13 @@ public class NfcInFlutterPlugin implements MethodCallHandler,
         return false;
     }
 
+    private String getNDEFTagID(Ndef ndef) {
+        byte[] idByteArray = ndef.getTag().getId();
+        // Fancy string formatting snippet is from
+        // https://gist.github.com/luixal/5768921#gistcomment-1788815
+        return String.format("%0" + (idByteArray.length * 2) + "X", new BigInteger(1, idByteArray));
+    }
+
     private void handleNDEFTagFromIntent(Tag tag) {
         Ndef ndef = Ndef.get(tag);
         if (ndef == null) {
@@ -253,7 +260,7 @@ public class NfcInFlutterPlugin implements MethodCallHandler,
 
     private Map<String, Object> formatEmptyNDEFMessage(Ndef ndef) {
         final Map<String, Object> result = new HashMap<>();
-        result.put("id", "");
+        result.put("id", getNDEFTagID(ndef));
         result.put("message_type", "ndef");
         result.put("type", "");
         result.put("writable", ndef.isWritable());
@@ -439,10 +446,7 @@ public class NfcInFlutterPlugin implements MethodCallHandler,
             recordMap.put("tnf", tnfValue);
             records.add(recordMap);
         }
-        byte[] idByteArray = ndef.getTag().getId();
-        // Fancy string formatting snippet is from
-        // https://gist.github.com/luixal/5768921#gistcomment-1788815
-        result.put("id", String.format("%0" + (idByteArray.length * 2) + "X", new BigInteger(1, idByteArray)));
+        result.put("id", getNDEFTagID(ndef));
         result.put("message_type", "ndef");
         result.put("type", ndef.getType());
         result.put("records", records);

--- a/android/src/main/java/me/andisemler/nfc_in_flutter/NfcInFlutterPlugin.java
+++ b/android/src/main/java/me/andisemler/nfc_in_flutter/NfcInFlutterPlugin.java
@@ -195,6 +195,7 @@ public class NfcInFlutterPlugin implements MethodCallHandler,
             ndef.connect();
             NdefMessage message = ndef.getNdefMessage();
             if (message == null) {
+                eventSuccess(formatEmptyNDEFMessage(ndef));
                 return;
             }
             try {
@@ -248,6 +249,25 @@ public class NfcInFlutterPlugin implements MethodCallHandler,
         }
         Map result = formatNDEFMessageToResult(ndef, message);
         eventSuccess(result);
+    }
+
+    private Map<String, Object> formatEmptyNDEFMessage(Ndef ndef) {
+        final Map<String, Object> result = new HashMap<>();
+        result.put("id", "");
+        result.put("message_type", "ndef");
+        result.put("type", "");
+        result.put("writable", ndef.isWritable());
+        List<Map<String, String>> records = new ArrayList<>();
+        Map<String, String> emptyRecord = new HashMap<>();
+        emptyRecord.put("tnf", "empty");
+        emptyRecord.put("id", "");
+        emptyRecord.put("type", "");
+        emptyRecord.put("payload", "");
+        emptyRecord.put("data", "");
+        emptyRecord.put("languageCode", "");
+        records.add(emptyRecord);
+        result.put("records", records);
+        return result;
     }
 
     private Map<String, Object> formatNDEFMessageToResult(Ndef ndef, NdefMessage message) {

--- a/example/lib/read_example_screen.dart
+++ b/example/lib/read_example_screen.dart
@@ -13,6 +13,10 @@ class _ReadExampleScreenState extends State<ReadExampleScreen> {
   void _startScanning() {
     setState(() {
       _stream = NFC.readNDEF(once: true).listen((NDEFMessage message) {
+        if (message.isEmpty) {
+          print("Read empty NDEF message");
+          return;
+        }
         print("Read NDEF message with ${message.records.length} records");
         for (NDEFRecord record in message.records) {
           print(

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -299,6 +299,16 @@ class NDEFMessage implements NFCMessage {
     return null;
   }
 
+  bool get isEmpty {
+    if (records.length == 0) {
+      return true;
+    }
+    if (records.length == 1 && records[0].tnf == NFCTypeNameFormat.empty) {
+      return true;
+    }
+    return false;
+  }
+
   // data returns the contents of the first non-empty record. If all records
   // are empty it will return null.
   String get data {


### PR DESCRIPTION
This PR should:
- allow tags with empty NDEF messages to be read on Android
- make it easier to check if a NDEF message is empty with the new `NDEFMessage.isEmpty` method