### PR TITLE
add parameter for ios alert message handling

### DIFF
--- a/ios/Classes/NfcInFlutterPlugin.h
+++ b/ios/Classes/NfcInFlutterPlugin.h
@@ -2,7 +2,7 @@
 #import <CoreNFC/CoreNFC.h>
 
 @protocol NFCWrapper <FlutterStreamHandler>
-- (void)startReading:(BOOL)once;
+- (void)startReading:(BOOL)once alertMessage:(NSString* _Nonnull)alertMessage;
 - (BOOL)isEnabled;
 - (void)writeToTag:(NSDictionary* _Nonnull)data completionHandler:(void (^_Nonnull) (FlutterError * _Nullable error))completionHandler;
 @end

--- a/ios/Classes/NfcInFlutterPlugin.m
+++ b/ios/Classes/NfcInFlutterPlugin.m
@@ -46,7 +46,7 @@
         result([NSNumber numberWithBool:[wrapper isEnabled]]);
     } else if ([@"startNDEFReading" isEqualToString:call.method]) {
         NSDictionary* args = call.arguments;
-        [wrapper startReading:[args[@"scan_once"] boolValue]];
+        [wrapper startReading:[args[@"scan_once"] boolValue] alertMessage:args[@"alert_message"]];
         result(nil);
     } else if ([@"writeNDEF" isEqualToString:call.method]) {
         NSDictionary* args = call.arguments;
@@ -435,9 +435,10 @@
     return self;
 }
     
-- (void)startReading:(BOOL)once {
+- (void)startReading:(BOOL)once alertMessage:(NSString* _Nonnull)alertMessage {
     if (session == nil) {
         session = [[NFCNDEFReaderSession alloc]initWithDelegate:self queue:dispatchQueue invalidateAfterFirstRead: once];
+        session.alertMessage = alertMessage;
     }
     [self->session beginSession];
 }
@@ -598,7 +599,7 @@
     // https://knowyourmeme.com/photos/1483348-bugs-bunnys-no
     return NO;
 }
-- (void)startReading:(BOOL)once {
+- (void)startReading:(BOOL)once alertMessage:(NSString* _Nonnull)alertMessage {
     return;
 }
 

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -60,10 +60,11 @@ class NFC {
     });
   }
 
-  static void _startReadingNDEF(bool once, NFCReaderMode readerMode) {
+  static void _startReadingNDEF(bool once, String message, NFCReaderMode readerMode) {
     // Start reading
     Map arguments = {
       "scan_once": once,
+      "alert_message": message,
       "reader_mode": readerMode.name,
     }..addAll(readerMode._options);
     _channel.invokeMethod("startNDEFReading", arguments);
@@ -80,6 +81,12 @@ class NFC {
       /// throwOnUserCancel decides if a [NFCUserCanceledSessionException] error
       /// should be thrown on iOS when the user clicks Cancel/Done.
       bool throwOnUserCancel = true,
+
+      /// message specify the message shown to the user when the NFC modal is
+      /// open
+      ///
+      /// This is ignored on Android as it does not have NFC modal
+      String message = "",
 
       /// readerMode specifies which mode the reader should use. By default it
       /// will use the normal mode, which scans for tags normally without
@@ -145,7 +152,7 @@ class NFC {
     };
 
     try {
-      _startReadingNDEF(once, const NFCNormalReaderMode());
+      _startReadingNDEF(once, message, const NFCNormalReaderMode());
     } on PlatformException catch (err) {
       if (err.code == "NFCMultipleReaderModes") {
         throw NFCMultipleReaderModesException();
@@ -165,6 +172,12 @@ class NFC {
 
       /// once will stop reading after the first tag has been read.
       bool once = false,
+
+      /// message specify the message shown to the user when the NFC modal is
+      /// open
+      ///
+      /// This is ignored on Android as it does not have NFC modal
+      String message = "",
 
       /// readerMode specifies which mode the reader should use.
       NFCReaderMode readerMode = const NFCNormalReaderMode()}) {
@@ -200,7 +213,7 @@ class NFC {
     };
 
     try {
-      _startReadingNDEF(once, readerMode);
+      _startReadingNDEF(once, message, readerMode);
     } on PlatformException catch (err) {
       if (err.code == "NFCMultipleReaderModes") {
         throw NFCMultipleReaderModesException();


### PR DESCRIPTION
Added a parameter to let developer specify an alert message to show in the ios modal NFC window (https://developer.apple.com/documentation/corenfc/nfcreadersession/2919987-alertmessage).