### PR TITLE
Fix reader mode issue on Android

### DIFF
--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -128,7 +128,7 @@ class NFC {
       _startReadingNDEF(
         once,
         alertMessage,
-        const NFCNormalReaderMode(),
+        readerMode,
       );
     } on PlatformException catch (err) {
       if (err.code == "NFCMultipleReaderModes") {


### PR DESCRIPTION
On Android, NFCDispatchReaderMode should be supported.

Signed-off-by: Jason Wang <Jason.Wang@aplm.co.nz>